### PR TITLE
Use spanIdGenerator for decoding spans in SpanCodec.Colfer

### DIFF
--- a/kamon-core/src/main/scala/kamon/trace/SpanCodec.scala
+++ b/kamon-core/src/main/scala/kamon/trace/SpanCodec.scala
@@ -137,8 +137,8 @@ object SpanCodec {
 
         val spanContext = SpanContext(
           traceID = identityProvider.traceIdGenerator().from(colferSpan.traceID),
-          spanID = identityProvider.traceIdGenerator().from(colferSpan.spanID),
-          parentID = identityProvider.traceIdGenerator().from(colferSpan.parentID),
+          spanID = identityProvider.spanIdGenerator().from(colferSpan.spanID),
+          parentID = identityProvider.spanIdGenerator().from(colferSpan.parentID),
           samplingDecision = byteToSamplingDecision(colferSpan.samplingDecision)
         )
 


### PR DESCRIPTION
Right now `traceIdGenerator` is used for all decoding, which causes problems when `traceId` and `spanId` are in different format.
This works fine in `SpanCodec.B3` so is probably a mistake.